### PR TITLE
Added compatibility with OTP 24+

### DIFF
--- a/kazoo_node.c
+++ b/kazoo_node.c
@@ -1254,7 +1254,8 @@ static switch_status_t handle_mod_kazoo_request(ei_node_t *ei_node, erlang_msg *
 	} else if (arity == 3 && !strncmp(atom, "$gen_call", 9)) {
 		switch_status_t status;
 		ei_send_msg_t *send_msg = NULL;
-		erlang_ref ref;
+		int ref_start, ref_len = 0;
+		char *ref = NULL;
 
 		switch_malloc(send_msg, sizeof(*send_msg));
 		ei_x_new_with_version(&send_msg->buf);
@@ -1282,16 +1283,23 @@ static switch_status_t handle_mod_kazoo_request(ei_node_t *ei_node, erlang_msg *
 		}
 
 		/* ...ref()}, {_, _}} = Buf */
-		if (ei_decode_ref(buf->buff, &buf->index, &ref)) {
+		ref_start = buf->index;
+		if (ei_skip_term(buf->buff, &buf->index)) { /* skip the whole tag/ref, is an opaque after all */
 			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Received erlang call without a reply tag (ensure you are using Kazoo v2.14+).\n");
 			ei_x_free(&send_msg->buf);
 			switch_safe_free(send_msg);
 			return SWITCH_STATUS_GENERR;
 		}
+		ref_len = buf->index - ref_start;
+
+		switch_malloc(ref, ref_len);
+		memcpy(ref, &buf->buff[ref_start], ref_len);
 
 		/* send_msg->buf = {ref(), ... */
 		ei_x_encode_tuple_header(&send_msg->buf, 2);
-		ei_x_encode_ref(&send_msg->buf, &ref);
+		ei_x_append_buf(&send_msg->buf, ref, ref_len);
+
+		switch_safe_free(ref);
 
 		status = handle_kazoo_request(ei_node, &msg->from, buf, &send_msg->buf);
 
@@ -1311,9 +1319,10 @@ static switch_status_t handle_mod_kazoo_request(ei_node_t *ei_node, erlang_msg *
 /* fake enough of the net_kernel module to be able to respond to net_adm:ping */
 static switch_status_t handle_net_kernel_request(ei_node_t *ei_node, erlang_msg *msg, ei_x_buff *buf) {
 	int version, size, type, arity;
+	int ref_start, ref_len = 0;
 	char atom[MAXATOMLEN + 1];
 	ei_send_msg_t *send_msg = NULL;
-	erlang_ref ref;
+	char *ref = NULL;
 
 	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Received net_kernel message, attempting to reply\n");
 
@@ -1361,8 +1370,18 @@ static switch_status_t handle_net_kernel_request(ei_node_t *ei_node, erlang_msg 
 	}
 
 	/* {Pid, Ref}=Sender */
-	if (ei_decode_pid(buf->buff, &buf->index, &send_msg->pid) || ei_decode_ref(buf->buff, &buf->index, &ref)) {
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Unable to decode erlang pid or ref of the net_kernel tuple second element\n");
+	if (!ei_decode_pid(buf->buff, &buf->index, &send_msg->pid)) {
+		ref_start = buf->index;
+		if (ei_skip_term(buf->buff, &buf->index)) { /* skip the whole tag/ref, is an opaque after all */
+			switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Unable to decode erlang ref/tag of the net_kernel tuple second element\n");
+			goto error;
+		}
+		ref_len = buf->index - ref_start;
+
+		switch_malloc(ref, ref_len);
+		memcpy(ref, &buf->buff[ref_start], ref_len);
+	} else {
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "Unable to decode erlang pid of the net_kernel tuple second element\n");
 		goto error;
 	}
 
@@ -1390,8 +1409,10 @@ static switch_status_t handle_net_kernel_request(ei_node_t *ei_node, erlang_msg 
 
 	/* To ! {Tag, Reply} */
 	ei_x_encode_tuple_header(&send_msg->buf, 2);
-	ei_x_encode_ref(&send_msg->buf, &ref);
+	ei_x_append_buf(&send_msg->buf, ref, ref_len);
 	ei_x_encode_atom(&send_msg->buf, "yes");
+
+	switch_safe_free(ref);
 
 	if (switch_queue_trypush(ei_node->send_msgs, send_msg) != SWITCH_STATUS_SUCCESS) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "unable to queue net kernel message\n");
@@ -1403,6 +1424,7 @@ static switch_status_t handle_net_kernel_request(ei_node_t *ei_node, erlang_msg 
 error:
 	ei_x_free(&send_msg->buf);
 	switch_safe_free(send_msg);
+	switch_safe_free(ref);
 	return SWITCH_STATUS_GENERR;
 }
 


### PR DESCRIPTION
The original PR was made by @xadhoom : https://github.com/signalwire/freeswitch/pull/1338
It was approved but has not been merged.

It adds compatibility with OTP 24+. Older versions are still working.
OTP 25:
```
(node@freeswitch.khabulyak.su)25> gen_server:call({'mod_kazoo', 'freeswitch@freeswitch.khabulyak.su'}, {'api', 'create_uuid', ""}).
{ok,<<"6ef23ff2-5635-4d55-bacb-f1d772ff1e94">>}
(node@freeswitch.khabulyak.su)26> gen_server:call({'mod_kazoo', 'freeswitch@freeswitch.khabulyak.su'}, {'api', 'version', ""
}).
{ok,<<"FreeSWITCH Version 1.10.12-release-10222002881-a88d069d6f+git~20240802T210227Z~a88d069d6f~64bit (-release-10"...>>}
```

OTP 23:
```
(node@khabulyak.su)3> gen_server:call({'mod_kazoo', 'freeswitch@freeswitch.khabulyak.su'}, {'api', 'create_uuid', ""}).
{ok,<<"416997ae-61cf-4a5e-bf16-a4d212771f87">>}
(node@khabulyak.su)4> gen_server:call({'mod_kazoo', 'freeswitch@freeswitch.khabulyak.su'}, {'api', 'create_uuid', ""}).
{ok,<<"18b8ae0f-ec4c-466e-b606-42e6ca14ddc7">>}
(node@khabulyak.su)5> gen_server:call({'mod_kazoo', 'freeswitch@freeswitch.khabulyak.su'}, {'api', 'status', ""}).
{ok,<<"UP 0 years, 0 days, 0 hours, 0 minutes, 46 seconds, 240 milliseconds, 91 microseconds\nFreeSWITCH (Version 1."...>>}
```